### PR TITLE
既存の日程候補の更新処理、キャンセルボタンの追加

### DIFF
--- a/routes/schedules.js
+++ b/routes/schedules.js
@@ -175,6 +175,41 @@ router.post('/:scheduleId', authenticationEnsurer, csrfProtection, (req, res, ne
             // 追加されているかチェック
             const candidateNames = parseCandidateNames(req);
             if (candidateNames) {
+
+              // ↓↓↓↓↓ debug ここから追加 ↓↓↓↓↓
+              let idx = 0; // 添え字
+              candidates.forEach((a) => {
+                // 確認用 debugログ
+                console.log("a.candidateId:" + a.candidateId);
+                console.log("a.candidateName:" + a.candidateName);
+                console.log("candidateId[idx]:"+ req.body.cndGroupID[idx]);
+                console.log("candidateName[idx]:" + req.body.cndGroupName[idx]);
+                console.log("candidateId:" + req.body.cndGroupID);
+                console.log("candidateName:" + req.body.cndGroupName);
+
+                // 既存候補日を更新
+                if (Array.isArray(req.body.cndGroupID)){ // 配列かどうかの判断
+                  Candidate.update({
+                    candidateName: req.body.cndGroupName[idx] },{
+                    where: { candidateId: req.body.cndGroupID[idx] }　//where: { candidateId: a.candidateId }
+                  })
+                  // debugログ
+                  console.log("isArray");
+                } else {
+                  // 既存候補日が1件の時は配列にならないので添え字を使わない
+                  Candidate.update({
+                    candidateName: req.body.cndGroupName },{
+                    where: { candidateId: req.body.cndGroupID }
+                  })
+                  // debugログ
+                  console.log("isNotArray");
+                }
+                console.log("----------------------------------------");
+                // 添え字をカウントアップ
+                idx ++;
+              });
+              // ↑↑↑↑↑ debug ここまで ↑↑↑↑↑
+              
               createCandidatesAndRedirect(candidateNames, schedule.scheduleId, res);
             } else {
               res.redirect('/schedules/' + schedule.scheduleId);
@@ -231,7 +266,7 @@ function createCandidatesAndRedirect(candidateNames, scheduleId, res) {
       scheduleId: scheduleId
     };});
     Candidate.bulkCreate(candidates).then(() => {
-          res.redirect('/schedules/' + scheduleId);
+           res.redirect('/schedules/' + scheduleId);
     });
 }
 

--- a/views/edit.jade
+++ b/views/edit.jade
@@ -14,11 +14,16 @@ block content
       label 既存の日程候補
       ul(class="list-group")
         each candidate in candidates
-          li(class="list-group-item") #{candidate.candidateName}
+          // ↓↓↓↓↓ debug ここから修正 ↓↓↓↓↓
+          // li(class="list-group-item") #{candidate.candidateName}
+          input(type="hidden" name="cndGroupID" value="#{candidate.candidateId}")
+          input(class="list-group-item" type="text" name="cndGroupName" value="#{candidate.candidateName}")
+          // ↑↑↑↑↑ debug ここまで ↑↑↑↑↑
       label(for="candidates") 候補日程の追加 (改行して複数入力してください)
       textarea(id="candidates" class="form-control" name="candidates")
     div
       button(class="btn btn-info" type="submit") 以上の内容で予定を編集する
+      a(class="btn btn-info" style="margin: 10px;" href="/schedules/#{schedule.scheduleId}") キャンセルして前画面に戻る
   h3 危険な変更
   form(method="post", action="/schedules/#{schedule.scheduleId}?delete=1")
     input(type="hidden" name="_csrf" value!="#{csrfToken}")

--- a/views/schedule.jade
+++ b/views/schedule.jade
@@ -8,6 +8,10 @@ block content
       p(style="white-space:pre;") #{schedule.memo}
     div(class="panel-footer")
       p 作成者: #{schedule.user.username}
+  div(class="form-group")
+    label(for="shareURL") 共有用 URL:
+    - var herokuURL = process.env.HEROKU_URL ? process.env.HEROKU_URL : 'http://localhost:8000/'
+    input(id="shareURL" class="form-control" type="text" value="#{herokuURL}schedules/#{schedule.scheduleId}/")      
   - var isMine = parseInt(user.id) === schedule.user.userId
   if isMine
     div


### PR DESCRIPTION
練習につきマージ不要です。

1.「予定の編集」画面(localhost:8000/schedules/～/edit)にて[既存の日程候補]を修正できるようにしました。「予定の編集」画面にて[既存の日程候補]を修正し、[以上の内容で予定を編集する]ボタンをクリックで更新できます。
※candidateテーブル更新時のキーとしてhiddenから取得したcandidateIDを使用しております。セキュリティ的に問題があるかもしれませんが、他のやり方が思いつきませんでした。

2.「予定の編集」画面に[キャンセルして前画面に戻る]ボタンを追加し、出欠画面に戻れるようにしました。

