### PR TITLE
宿題

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -11,6 +11,10 @@ const User = loader.database.define('users', {
   username: {
     type: Sequelize.STRING,
     allowNull: false
+  },
+  icon: {
+    type: Sequelize.STRING,
+    allowNull: true
   }
 }, {
     freezeTableName: true,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "node-uuid": "^1.4.7",
     "passport": "^0.3.2",
     "passport-github2": "^0.1.9",
+    "passport-twitter": "^1.0.4",
     "pg": "^4.4.3",
     "pg-hstore": "^2.3.2",
     "sequelize": "^3.15.1",
@@ -35,5 +36,5 @@
   },
   "engines": {
     "node": "4.2.3"
-   }
+  }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,6 +7,7 @@ const moment = require('moment-timezone');
 /* GET home page. */
 router.get('/', (req, res, next) => {
   const title = '予定調整くん';
+  //  console.log(req);
   if (req.user) {
     Schedule.findAll({
       where: {

--- a/routes/schedules.js
+++ b/routes/schedules.js
@@ -36,7 +36,7 @@ router.get('/:scheduleId', authenticationEnsurer, (req, res, next) => {
     include: [
       {
         model: User,
-        attributes: ['userId', 'username']
+        attributes: ['userId', 'username', 'icon']
       }],
     where: {
       scheduleId: req.params.scheduleId
@@ -61,7 +61,7 @@ router.get('/:scheduleId', authenticationEnsurer, (req, res, next) => {
       include: [
         {
           model: User,
-          attributes: ['userId', 'username']
+          attributes: ['userId', 'username', 'icon']
         }
       ],
       where: { scheduleId: storedSchedule.scheduleId },
@@ -174,7 +174,7 @@ router.post('/:scheduleId', authenticationEnsurer, csrfProtection, (req, res, ne
           }).then((candidates) => {
             // 追加されているかチェック
             const candidateNames = parseCandidateNames(req);
-            if (candidateNames) {
+            if (candidateNames && !(candidateNames.length === 1 && candidateNames[0] === '')) {
               createCandidatesAndRedirect(candidateNames, schedule.scheduleId, res);
             } else {
               res.redirect('/schedules/' + schedule.scheduleId);

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -7,6 +7,7 @@ html
     meta(name="viewport" content="width=device-width, initial-scale=1")
     link(rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous")
     link(rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap-theme.min.css" integrity="sha384-fLW2N01lMqjakBkx3l/M9EahuwpSfeNvV63J5ezn3uZzapT0u7EYsXMjQV+0En5r" crossorigin="anonymous")
+    link(href="//netdna.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css" rel="stylesheet")
   body
     nav(class="navbar navbar-default")
       div(class="navbar-header")
@@ -15,7 +16,9 @@ html
         ul(class="nav navbar-nav navbar-right")
           if user
             li
-              a(href="/logout") #{user.username} をログアウト
+              a(href="/logout")
+                img(height="15" width="15" src="#{user.__icon}")
+                span #{user.username} をログアウト
           else
             li
               a(href="/login") ログイン

--- a/views/login.jade
+++ b/views/login.jade
@@ -1,4 +1,11 @@
 extends layout
 
 block content
-  a(class="btn btn-info" href="/auth/github") GitHubでログイン
+  div
+    a(class="btn btn-info" href="/auth/github" style="padding:2px 5px")
+      i(class="fa fa-github" aria-hidden="true" style="font-size:200%; margin-right:5px")
+      span(style="vertical-align: 20%;") GitHubでログイン
+  div(style="margin-top:5px")
+    a(class="btn btn-info" href="/auth/twitter" style="padding:2px 5px")
+      i(class="fa fa-twitter" aria-hidden="true" style="font-size:200%; margin-right:5px")
+      span(style="vertical-align: 20%;") Twitterでログイン

--- a/views/schedule.jade
+++ b/views/schedule.jade
@@ -7,7 +7,13 @@ block content
     div(class="panel-body")
       p(style="white-space:pre;") #{schedule.memo}
     div(class="panel-footer")
-      p 作成者: #{schedule.user.username}
+      p 作成者:
+        img(height="15" width="15" src="#{schedule.user.icon}")
+        span #{schedule.user.username}
+  div(class="form-group")
+    label(for="shareURL") 共有用 URL:
+    - var herokuURL = process.env.HEROKU_URL ? process.env.HEROKU_URL : 'http://localhost:8000/'
+    input(id="shareURL" class="form-control" type="text" value="#{herokuURL}schedules/#{schedule.scheduleId}/")
   - var isMine = parseInt(user.id) === schedule.user.userId
   if isMine
     div


### PR DESCRIPTION
- twitterでもログインできるように
![fontawesome](https://cloud.githubusercontent.com/assets/3596712/24049752/564db47a-0b70-11e7-9c9a-371e9a8840f2.png)
- font-awesome を導入しログインボタンをわかりやすく
- ユーザーのiconを表示するように(github, twitter両対応)
![sakuseisya](https://cloud.githubusercontent.com/assets/3596712/24049847/82e09c78-0b70-11e7-8e80-a66dc1efb895.png)
![logout](https://cloud.githubusercontent.com/assets/3596712/24049850/83dda3f0-0b70-11e7-8e06-4df968813fe1.png)
- icon url を保存できるようにUserモデルに icon を追加し以下のSQLを実行
- `ALTER TABLE users ADD COLUMN icon VARCHAR(255);`

テストの追加とかgithubとtwitterの認証で似たようなコードが並んでリファクタリングもっとできそう、とかいろいろやりたい事は山積みですがとりあえず動くところまでできたので。
