### PR TITLE
不正なUUIDでクラッシュしないよう修正

### DIFF
--- a/routes/schedules.js
+++ b/routes/schedules.js
@@ -119,6 +119,10 @@ router.get('/:scheduleId', authenticationEnsurer, (req, res, next) => {
         commentMap: commentMap
       });
     });
+  }).catch(() => {
+    const err = new Error('リクエストが不正です');
+    err.status = 400;
+    next(err);
   });
 });
 
@@ -145,6 +149,10 @@ router.get('/:scheduleId/edit', authenticationEnsurer, csrfProtection, (req, res
       err.status = 404;
       next(err);
     }
+  }).catch(() => {
+    const err = new Error('リクエストが不正です');
+    err.status = 400;
+    next(err);
   });
 });
 


### PR DESCRIPTION
/schedules/:scheduleId アクセス時、scheduleId が正しい UUID のフォーマットに則っていない(数字が１桁足りない等)とサーバがクラッシュしてしまうので、ひとまずHTTPステータス400で返してクラッシュしないように修正しました。

練習問題の解答です。
マージ不要です。
