### PR TITLE
予定一覧を表示した時に新着の予定の横へマークをつける機能を追加

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -14,8 +14,13 @@ block content
         tr
           th 予定名
           th 更新日時
+        - var now = new Date()
+        - var recentTimeSpan = 10000 // 新着間隔を ms 単位で指定
         each schedule in schedules
           tr
             td
+              if now - schedule.updatedAt < recentTimeSpan
+                span.badge.badge-success New!
+                span &nbsp;
               a(href=`/schedules/${schedule.scheduleId}`) #{schedule.scheduleName}
             td #{schedule.formattedUpdatedAt}


### PR DESCRIPTION
現在はテストのしやすさの都合で、10秒以内に編集された予定に新着マークをつけています。

手元の環境で動作確認済みです。
よろしくお願いします。