### PR TITLE
他の人が作成した予定で出欠入力済の予定一覧を表示

### DIFF
--- a/app/entry.js
+++ b/app/entry.js
@@ -12,9 +12,10 @@ $('.availability-toggle-button').each((i, e) => {
     const candidateId = button.data('candidate-id');
     const availability = parseInt(button.data('availability'));
     const nextAvailability = (availability + 1) % 3;
-    $.post(`/schedules/${scheduleId}/users/${userId}/candidates/${candidateId}`,
+    $.post(
+      `/schedules/${scheduleId}/users/${userId}/candidates/${candidateId}`,
       { availability: nextAvailability },
-      (data) => {
+      data => {
         button.data('availability', data.availability);
         const availabilityLabels = ['欠', '？', '出'];
         button.text(availabilityLabels[data.availability]);
@@ -22,7 +23,14 @@ $('.availability-toggle-button').each((i, e) => {
         const buttonStyles = ['btn-danger', 'btn-secondary', 'btn-success'];
         button.removeClass('btn-danger btn-secondary btn-success');
         button.addClass(buttonStyles[data.availability]);
-      });
+
+        const availabilityCounts = button.closest('tr').find('td.availability');
+        availabilityCounts[availabilityCounts.length - availability - 1]
+          .textContent--;
+        availabilityCounts[availabilityCounts.length - nextAvailability - 1]
+          .textContent++;
+      }
+    );
   });
 });
 
@@ -32,10 +40,12 @@ buttonSelfComment.click(() => {
   const userId = buttonSelfComment.data('user-id');
   const comment = prompt('コメントを255文字以内で入力してください。');
   if (comment) {
-    $.post(`/schedules/${scheduleId}/users/${userId}/comments`,
+    $.post(
+      `/schedules/${scheduleId}/users/${userId}/comments`,
       { comment: comment },
-      (data) => {
+      data => {
         $('#self-comment').text(data.comment);
-      });
+      }
+    );
   }
 });

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,28 +1,51 @@
 'use strict';
 const express = require('express');
 const router = express.Router();
+const loader = require('../models/sequelize-loader');
+const Op = loader.Sequelize.Op;
 const Schedule = require('../models/schedule');
+const User = require('../models/user');
+const Availability = require('../models/Availability');
 const moment = require('moment-timezone');
 
 /* GET home page. */
 router.get('/', (req, res, next) => {
   const title = '予定調整くん';
   if (req.user) {
-    Schedule.findAll({
-      where: {
-        createdBy: req.user.id
-      },
-      order: [['updatedAt', 'DESC']]
-    }).then((schedules) => {
-      schedules.forEach((schedule) => {
-        schedule.formattedUpdatedAt = moment(schedule.updatedAt).tz('Asia/Tokyo').format('YYYY/MM/DD HH:mm');
+    Availability.findAll({
+      attributes: ['scheduleId'],
+      where: { userId: req.user.id },
+      group: ['scheduleId'],
+    })
+      .then(availabilities => {
+        return Schedule.findAll({
+          include: [
+            {
+              model: User,
+              attributes: ['userId', 'username'],
+            },
+          ],
+          where: {
+            [Op.or]: {
+              createdBy: req.user.id,
+              scheduleId: { [Op.in]: availabilities.map(a => a.scheduleId) },
+            },
+          },
+          order: [['updatedAt', 'DESC']],
+        });
+      })
+      .then(schedules => {
+        schedules.forEach(schedule => {
+          schedule.formattedUpdatedAt = moment(schedule.updatedAt)
+            .tz('Asia/Tokyo')
+            .format('YYYY/MM/DD HH:mm');
+        });
+        res.render('index', {
+          title: title,
+          user: req.user,
+          schedules: schedules,
+        });
       });
-      res.render('index', {
-        title: title,
-        user: req.user,
-        schedules: schedules
-      });
-    });
   } else {
     res.render('index', { title: title, user: req.user });
   }

--- a/views/index.pug
+++ b/views/index.pug
@@ -7,15 +7,30 @@ block content
   if user
     div
       a(href="/schedules/new").btn.btn-info 予定を作る
-    - var hasSchedule = schedules.length > 0
-    if hasSchedule
+    - var mySchedules = schedules.filter(s => s.createdBy === parseInt(user.id))
+    - var othersSchedules = schedules.filter(s => s.createdBy !== parseInt(user.id))
+    if mySchedules.length > 0
       h3.my-3 あなたの作った予定一覧
       table.table
         tr
           th 予定名
           th 更新日時
-        each schedule in schedules
+        each schedule in mySchedules
           tr
             td
               a(href=`/schedules/${schedule.scheduleId}`) #{schedule.scheduleName}
+            td #{schedule.formattedUpdatedAt}
+
+    if othersSchedules.length > 0
+      h3.my-3 他の人が作った予定一覧(出欠入力済のもの)
+      table.table
+        tr
+          th 予定名
+          th 作成者
+          th 更新日時
+        each schedule in othersSchedules
+          tr
+            td
+              a(href=`/schedules/${schedule.scheduleId}`) #{schedule.scheduleName}
+            td #{schedule.user.username}
             td #{schedule.formattedUpdatedAt}

--- a/views/schedule.pug
+++ b/views/schedule.pug
@@ -24,16 +24,16 @@ block content
         each user in users
           - var availability = availabilityMapMap.get(user.userId).get(candidate.candidateId)
           - var availabilityLabels = ['欠', '？', '出'];
-          - var buttonStyles = ['btn-danger', 'btn-secondary', 'btn-success'];
+          - var buttonStyles = ['danger', 'secondary', 'success'];
           td
             if user.isSelf
-              button(class=`availability-toggle-button btn-lg ${buttonStyles[availability]}`
+              button(class=`availability-toggle-button btn-lg btn-${buttonStyles[availability]}`
                 data-schedule-id=schedule.scheduleId
                 data-user-id=user.userId
                 data-candidate-id=candidate.candidateId
                 data-availability=availability) #{availabilityLabels[availability]}
             else
-              h3 #{availabilityLabels[availability]}
+              button(class=`btn-lg btn-outline-${buttonStyles[availability]} disabled`) #{availabilityLabels[availability]}
     tr
       th コメント
       each user in users

--- a/views/schedule.pug
+++ b/views/schedule.pug
@@ -13,27 +13,31 @@ block content
     div
       a(href=`/schedules/${schedule.scheduleId}/edit`).btn.btn-info この予定を編集する
   h3.my-3 出欠表
+  - var availabilityLabels = ['欠', '？', '出'];
+  - var availabilityStyles = ['danger', 'secondary', 'success'];
   table.table.table-bordered
     tr
       th 予定
       each user in users
         th #{user.username}
+      each availabilityLabel, index in availabilityLabels.slice().reverse()
+        th(class=`text-${availabilityStyles.slice().reverse()[index]}`) #{availabilityLabel}
     each candidate in candidates
       tr
         th #{candidate.candidateName}
         each user in users
           - var availability = availabilityMapMap.get(user.userId).get(candidate.candidateId)
-          - var availabilityLabels = ['欠', '？', '出'];
-          - var buttonStyles = ['danger', 'secondary', 'success'];
           td
             if user.isSelf
-              button(class=`availability-toggle-button btn-lg btn-${buttonStyles[availability]}`
+              button(class=`availability-toggle-button btn-lg btn-${availabilityStyles[availability]}`
                 data-schedule-id=schedule.scheduleId
                 data-user-id=user.userId
                 data-candidate-id=candidate.candidateId
                 data-availability=availability) #{availabilityLabels[availability]}
             else
-              button(class=`btn-lg btn-outline-${buttonStyles[availability]} disabled`) #{availabilityLabels[availability]}
+              button(class=`btn-lg btn-outline-${availabilityStyles[availability]} disabled`) #{availabilityLabels[availability]}
+        each availabilityLabel, index in availabilityLabels.slice().reverse()
+          td(class=`availability text-${availabilityStyles.slice().reverse()[index]}`) #{users.filter(u => availabilityMapMap.get(u.userId).get(candidate.candidateId) === availabilityLabels.length - index - 1).length}
     tr
       th コメント
       each user in users
@@ -48,3 +52,6 @@ block content
           td
             p
               small #{commentMap.get(user.userId)}
+
+      each availabilityLabel in availabilityLabels
+        td


### PR DESCRIPTION
練習用のためマージ不要です。

他の人が作成した予定のうち、自分が出欠入力済の予定一覧をトップページに追加しました。
![image](https://user-images.githubusercontent.com/63276995/79437599-5e1b5080-800d-11ea-85b2-434ae0d6a893.png)

また、同時に以下の変更を加えています
-  他の人の出欠表示がチープだったので枠線付きのボタンに修正しました。
-  候補ごとの出欠数の表示

|変更前|変更後|
---|---
![image](https://user-images.githubusercontent.com/63276995/79438467-835c8e80-800e-11ea-8b97-9c2eef6ec44f.png)|![image](https://user-images.githubusercontent.com/63276995/79545766-3939e280-80cc-11ea-9107-e016009d9453.png)

