### PR TITLE
[fix] テスト項目「ログイン時はユーザー名が表示される」

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -13,7 +13,7 @@ const deleteScheduleAggregate = require('../routes/schedules').deleteScheduleAgg
 describe('/login', () => {
   before(() => {
     passportStub.install(app);
-    passportStub.login({ username: 'testuser' });
+    passportStub.login({ id: 0, username: 'testuser' });
   });
 
   after(() => {


### PR DESCRIPTION
`user.id` が定義されてないため、 `routes/index.js` が実行時エラーで落ちます。
2020のブランチでは動いていたので修正だけでも投げておきます。